### PR TITLE
fix: correct @source path for Tailwind to scan UI package

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@source "../../packages/ui/src";
+@source "../../../packages/ui/src";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Summary
- Fixed Tailwind CSS `@source` directive path in `globals.css`
- Changed from `../../packages/ui/src` to `../../../packages/ui/src`
- The incorrect path caused Tailwind to not scan the UI package for class names

## Problem
After the Turborepo migration, CSS styles from `@repo/ui` components were not being applied:
- Buttons displayed icons and text stacked vertically instead of inline
- Cards were missing visible borders and rounded corners
- Tabs had misaligned icons and text

## Root Cause
The `@source` directive path was wrong by one directory level:
- `globals.css` is at `/apps/web/app/globals.css`
- `../../` from there resolves to `/apps/` (wrong)
- `../../../` resolves to `/` root (correct)

## Test plan
- [x] Verified buttons now display icons inline with text
- [x] Verified cards have visible borders and rounded corners
- [x] Verified tabs have properly aligned icons
- [x] Tested Dashboard, Settings, and Documents pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)