### PR TITLE
fix: Correct connection status check in settings page

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -490,14 +490,14 @@ export default function SettingsPage() {
       const data = await response.json();
       setConnectionStatus((prev) => ({
         ...prev,
-        [service]: data.status === "connected" ? "success" : "error",
+        [service]: data.status === "success" ? "success" : "error",
       }));
 
       // If connection successful, load models directly (avoid stale closure)
-      if (data.status === "connected" && service === "ollama") {
+      if (data.status === "success" && service === "ollama") {
         fetchOllamaModels();
       }
-      if (data.status === "connected" && service === "mistral") {
+      if (data.status === "success" && service === "mistral") {
         fetchMistralModels();
       }
     } catch {
@@ -545,14 +545,14 @@ export default function SettingsPage() {
       const data = await response.json();
       setConnectionStatus((prev) => ({
         ...prev,
-        [service]: data.status === "connected" ? "success" : "error",
+        [service]: data.status === "success" ? "success" : "error",
       }));
 
       // If connection successful, load models
-      if (data.status === "connected" && service === "ollama") {
+      if (data.status === "success" && service === "ollama") {
         fetchOllamaModels();
       }
-      if (data.status === "connected" && service === "mistral") {
+      if (data.status === "success" && service === "mistral") {
         fetchMistralModels();
       }
     } catch {


### PR DESCRIPTION
## Summary
Fix settings page showing all services as errors even when they're working.

## Problem
Same issue as PR #14 - the frontend was checking `data.status === "connected"` but the backend API returns `data.status === "success"`.

## Solution
Changed all 6 occurrences to check for `"success"` instead of `"connected"`.

## Test plan
- [x] Settings page connection tests now show green when successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a frontend-backend API contract mismatch that was causing connection status tests to always show as errors in the settings page. The issue was identified and partially fixed in PR #14 for the dashboard, but the settings page still had the same bug.

## What Changed
The settings page was checking `data.status === "connected"` in 6 locations, but the backend API returns `data.status === "success"` (as defined in `apps/backend/src/api/settings/api.ts`). This PR corrects all 6 occurrences across two functions:
- `testConnectionSilent()` - 3 occurrences (line 493, 497, 500)
- `testConnection()` - 3 occurrences (line 548, 552, 555)

## How It Fits
The backend connection test handlers (`testPaperlessConnection`, `testOllamaConnection`, `testMistralConnection`, `testQdrantConnection`) in `apps/backend/src/api/settings/handlers.ts` all return a `ConnectionTestResult` type with `status: "success" | "error"`. This PR aligns the frontend checks with that contract.

## Additional Finding
While reviewing, I discovered that the `ConnectionTest` interface in `apps/web/lib/api.ts` (line 322) also has the incorrect type `"connected" | "error"` instead of `"success" | "error"`. While this doesn't currently affect functionality (the settings page uses raw fetch instead of the typed API client), it should be fixed for consistency and future type safety.

### Confidence Score: 4/5

- This PR is safe to merge with one minor style improvement recommended
- The fix correctly addresses the stated issue by changing all 6 status checks from "connected" to "success", matching the backend API contract. The changes are straightforward string literal replacements with no logic changes. However, there's a related type definition issue in lib/api.ts that should be addressed for consistency, though it doesn't affect current functionality.
- Consider updating apps/web/lib/api.ts to fix the ConnectionTest type definition for future type safety

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/app/settings/page.tsx | 5/5 | Fixed 6 occurrences of incorrect status check from "connected" to "success" to match backend API response. Changes correctly applied to both testConnectionSilent and testConnection functions. |
| apps/web/lib/api.ts | 4/5 | Not changed in this PR, but contains a type mismatch in ConnectionTest interface - status field should be "success" | "error" not "connected" | "error" |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SettingsPage
    participant Backend
    participant Service as External Service<br/>(Ollama/Mistral/etc)

    User->>SettingsPage: Click "Test Connection"
    SettingsPage->>SettingsPage: setConnectionStatus("testing")
    SettingsPage->>Backend: POST /api/settings/test-connection/:service
    
    alt Service Reachable
        Backend->>Service: Test connection (fetch)
        Service-->>Backend: 200 OK
        Backend-->>SettingsPage: {status: "success", message: "Connected"}
        Note over SettingsPage: ✅ BEFORE: Checking "connected"<br/>✅ AFTER: Checking "success"
        SettingsPage->>SettingsPage: setConnectionStatus("success")
        
        alt Service is Ollama or Mistral
            SettingsPage->>Backend: GET /api/settings/{service}/models
            Backend-->>SettingsPage: {models: [...]}
            SettingsPage->>SettingsPage: Load models into UI
        end
    else Service Unreachable
        Backend->>Service: Test connection (fetch)
        Service-->>Backend: Error/Timeout
        Backend-->>SettingsPage: {status: "error", message: "Failed"}
        SettingsPage->>SettingsPage: setConnectionStatus("error")
    end
    
    SettingsPage-->>User: Display status indicator
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->